### PR TITLE
feat(auto-connect): detect Azure OpenAI credentials from Azure CLI

### DIFF
--- a/src/vs/workbench/contrib/void/browser/autoConnect/autoConnectService.ts
+++ b/src/vs/workbench/contrib/void/browser/autoConnect/autoConnectService.ts
@@ -89,8 +89,12 @@ export class AutoConnectService extends Disposable implements IAutoConnectServic
 	private _runDetection(): void {
 		if (this._neverAskAgain) return;
 
-		this._resolveGhToken().then(ghToken => {
-			return detectAllCredentials(this._fileService, ghToken, this._commandExecutor.execute.bind(this._commandExecutor));
+		Promise.all([
+			this._resolveGhToken(),
+			this._resolveAzToken(),
+			this._resolveAzEndpoint(),
+		]).then(([ghToken, azToken, azEndpoint]) => {
+			return detectAllCredentials(this._fileService, ghToken, azToken, azEndpoint, this._commandExecutor.execute.bind(this._commandExecutor));
 		}).then(all => {
 			console.log('[autoConnect] _runDetection: raw credential count:', all.length, all.map(c => `${c.providerName}/${c.source}`).join(', ') || '(none)');
 			const newCredentials = all.filter(c =>
@@ -139,8 +143,12 @@ export class AutoConnectService extends Disposable implements IAutoConnectServic
 	}
 
 	async detectCredentials(): Promise<IDetectedCredential[]> {
-		const ghToken = await this._resolveGhToken();
-		const all = await detectAllCredentials(this._fileService, ghToken, this._commandExecutor.execute.bind(this._commandExecutor));
+		const [ghToken, azToken, azEndpoint] = await Promise.all([
+			this._resolveGhToken(),
+			this._resolveAzToken(),
+			this._resolveAzEndpoint(),
+		]);
+		const all = await detectAllCredentials(this._fileService, ghToken, azToken, azEndpoint, this._commandExecutor.execute.bind(this._commandExecutor));
 		console.log('[autoConnect] detectCredentials: total:', all.length, all.map(c => `${c.providerName}/${c.source}`).join(', ') || '(none)');
 		this._detectedCredentials = all;
 		this._onDidDetectCredentials.fire(all);
@@ -169,6 +177,48 @@ export class AutoConnectService extends Disposable implements IAutoConnectServic
 			console.log('[autoConnect] _resolveGhToken: failed:', String(err));
 		}
 		return undefined;
+	}
+
+	private async _resolveAzToken(): Promise<string | undefined> {
+		// Shell out to `az account get-access-token` to obtain a Cognitive Services bearer token.
+		// Gracefully returns undefined if az is not installed, not logged in, or the command fails.
+		const command = isWindows
+			? `powershell.exe -NoProfile -Command "az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken --output tsv"`
+			: 'az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken --output tsv';
+		try {
+			const output = await this._commandExecutor.execute('az-token', command, 10000, 4096);
+			const token = output.trim().split(/\r?\n/).map(l => l.trim()).find(l => l.length > 10 && !l.toLowerCase().startsWith('error') && !l.toLowerCase().startsWith('warning'));
+			console.log('[autoConnect] _resolveAzToken: success:', !!token, 'length:', token?.length ?? 0);
+			return token || undefined;
+		} catch (err) {
+			console.log('[autoConnect] _resolveAzToken: failed (az not installed or not logged in):', String(err));
+			return undefined;
+		}
+	}
+
+	private async _resolveAzEndpoint(): Promise<string | undefined> {
+		// Shell out to `az cognitiveservices account list` (JSON) and extract the first
+		// Azure OpenAI (kind == "OpenAI") endpoint. Returns undefined if none found or
+		// if the command fails for any reason — this is detection-only, no resources are created.
+		const command = isWindows
+			? `powershell.exe -NoProfile -Command "az cognitiveservices account list --output json"`
+			: 'az cognitiveservices account list --output json';
+		try {
+			const output = await this._commandExecutor.execute('az-endpoint', command, 15000, 65536);
+			const trimmed = output.trim();
+			if (!trimmed || trimmed.startsWith('ERROR') || trimmed.startsWith('WARNING')) return undefined;
+			const accounts: any[] = JSON.parse(trimmed);
+			if (!Array.isArray(accounts)) return undefined;
+			// Prefer kind == "OpenAI"; fall back to first account with an endpoint
+			const openAiAccount = accounts.find(a => a.kind === 'OpenAI' && a.properties?.endpoint)
+				?? accounts.find(a => a.properties?.endpoint);
+			const endpoint: string | undefined = openAiAccount?.properties?.endpoint;
+			console.log('[autoConnect] _resolveAzEndpoint: found:', endpoint || '(none)');
+			return endpoint && endpoint.startsWith('https://') ? endpoint : undefined;
+		} catch (err) {
+			console.log('[autoConnect] _resolveAzEndpoint: failed (no subscription, no resources, or parse error):', String(err));
+			return undefined;
+		}
 	}
 
 	async applyCredentials(credentials: IDetectedCredential[]): Promise<void> {

--- a/src/vs/workbench/contrib/void/browser/autoConnect/envVarDetector.ts
+++ b/src/vs/workbench/contrib/void/browser/autoConnect/envVarDetector.ts
@@ -160,9 +160,11 @@ export async function detectAwsCredentials(fileService: IFileService): Promise<I
 	};
 }
 
-// --- Azure: env vars → ~/.azure/azureProfile.json ---
+// --- Azure: env vars → Azure CLI bearer token ---
+// azureProfile.json is used only for subscription display metadata, never as a standalone credential.
 
-export async function detectAzureCredentials(fileService: IFileService): Promise<IDetectedCredential | null> {
+export async function detectAzureCredentials(fileService: IFileService, azToken?: string, azEndpoint?: string): Promise<IDetectedCredential | null> {
+	// Strategy 1: AZURE_OPENAI_API_KEY env var — highest priority, skip CLI
 	const apiKey = findFirstEnvVar(AZURE_ENV_VARS.apiKey);
 	if (apiKey) {
 		const endpoint = findFirstEnvVar(AZURE_ENV_VARS.endpoint);
@@ -179,25 +181,39 @@ export async function detectAzureCredentials(fileService: IFileService): Promise
 		};
 	}
 
-	const home = getHomedir();
-	if (!home) return null;
-
-	const azureProfile = await readFileSafe(fileService, `${home}/.azure/azureProfile.json`);
-	if (!azureProfile) return null;
-
-	try {
-		const profile = JSON.parse(azureProfile);
-		const subscriptions = profile?.subscriptions;
-		if (subscriptions && subscriptions.length > 0) {
-			const defaultSub = subscriptions.find((s: any) => s.isDefault) || subscriptions[0];
-			return {
-				providerName: 'microsoftAzure',
-				source: 'config-file',
-				settings: {},
-				maskedDisplay: `Azure CLI (${defaultSub.name || defaultSub.id || 'logged in'})`,
-			};
+	// Strategy 2: Azure CLI bearer token (from `az account get-access-token`)
+	// azureProfile.json is read only for subscription label display, not as a credential.
+	if (azToken) {
+		let subscriptionLabel = '';
+		const home = getHomedir();
+		if (home) {
+			const azureProfile = await readFileSafe(fileService, `${home}/.azure/azureProfile.json`);
+			if (azureProfile) {
+				try {
+					const profile = JSON.parse(azureProfile);
+					const subscriptions = profile?.subscriptions;
+					if (subscriptions && subscriptions.length > 0) {
+						const defaultSub = subscriptions.find((s: any) => s.isDefault) || subscriptions[0];
+						subscriptionLabel = defaultSub.name || defaultSub.id || '';
+					}
+				} catch { /* malformed */ }
+			}
 		}
-	} catch { /* malformed */ }
+
+		const settings: Record<string, string> = { apiKey: azToken };
+		if (azEndpoint) settings['endpoint'] = azEndpoint;
+
+		const maskedDisplay = subscriptionLabel
+			? `az cli (${subscriptionLabel}) ${maskKey(azToken)}`
+			: `az cli ${maskKey(azToken)}`;
+
+		return {
+			providerName: 'microsoftAzure',
+			source: 'cli-auth',
+			settings,
+			maskedDisplay,
+		};
+	}
 
 	return null;
 }
@@ -453,8 +469,8 @@ export async function detectGitHubCliCredentials(fileService: IFileService, exte
 
 // --- Aggregate ---
 
-export async function detectAllCredentials(fileService: IFileService, ghCliToken?: string, run?: ShellRunner): Promise<IDetectedCredential[]> {
-	console.log('[autoConnect] detectAllCredentials: ghCliToken present:', !!ghCliToken, 'length:', ghCliToken?.length ?? 0);
+export async function detectAllCredentials(fileService: IFileService, ghCliToken?: string, azCliToken?: string, azCliEndpoint?: string, run?: ShellRunner): Promise<IDetectedCredential[]> {
+	console.log('[autoConnect] detectAllCredentials: ghCliToken present:', !!ghCliToken, 'length:', ghCliToken?.length ?? 0, 'azCliToken present:', !!azCliToken, 'azCliEndpoint:', azCliEndpoint || '(none)');
 	const results: IDetectedCredential[] = [];
 
 	const envVarResults = await detectEnvVarCredentials(fileService);
@@ -465,7 +481,7 @@ export async function detectAllCredentials(fileService: IFileService, ghCliToken
 
 	const [aws, azure, gcp, ghCli, gcm] = await Promise.all([
 		detectAwsCredentials(fileService),
-		detectAzureCredentials(fileService),
+		detectAzureCredentials(fileService, azCliToken, azCliEndpoint),
 		detectGcpCredentials(fileService),
 		detectGitHubCliCredentials(fileService, ghCliToken),
 		// Pass githubFromEnv so GCM doesn't run when GITHUB_TOKEN / GH_TOKEN already found

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -852,10 +852,13 @@ const AutoDetectCredentials = () => {
 						const { title } = displayInfoOfProviderName(cred.providerName)
 						const isApplied = appliedSet.has(cred.providerName)
 						const isExperimental = cred.providerName === 'microsoftAzure' || cred.providerName === 'googleVertex'
+						const displayTitle = cred.providerName === 'microsoftAzure' && cred.source === 'cli-auth'
+							? 'Azure OpenAI (az cli)'
+							: title
 
 						return <div key={cred.providerName} className='flex items-center gap-3 py-1.5 px-2 rounded-sm bg-void-bg-2'>
 							<span className='text-void-fg-2 min-w-[130px] text-sm font-medium'>
-								{title}
+								{displayTitle}
 								{isExperimental && <span className='ml-1.5 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 font-normal'>experimental</span>}
 							</span>
 							<span className='text-void-fg-3 font-mono text-xs'>{cred.maskedDisplay}</span>

--- a/src/vs/workbench/contrib/void/test/node/envVarDetector.test.ts
+++ b/src/vs/workbench/contrib/void/test/node/envVarDetector.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import {
 	detectEnvVarCredentials,
 	detectGitCredentialManagerCredentials,
+	detectAzureCredentials,
 } from '../../browser/autoConnect/envVarDetector.js';
 import { IFileService, IFileContent } from '../../../../../platform/files/common/files.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -215,6 +216,120 @@ suite('envVarDetector — detectGitCredentialManagerCredentials', () => {
 		};
 		const result = await detectGitCredentialManagerCredentials(emptyFs, runner, false);
 		assert.strictEqual(result, null, 'should return null when security CLI throws');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: detectAzureCredentials — Azure CLI bearer token
+// ---------------------------------------------------------------------------
+
+suite('envVarDetector — detectAzureCredentials (az cli)', () => {
+	let savedApiKey: string | undefined;
+	let savedEndpoint: string | undefined;
+
+	setup(() => {
+		savedApiKey = process.env['AZURE_OPENAI_API_KEY'];
+		savedEndpoint = process.env['AZURE_OPENAI_ENDPOINT'];
+		delete process.env['AZURE_OPENAI_API_KEY'];
+		delete process.env['AZURE_API_KEY'];
+		delete process.env['AZURE_OPENAI_ENDPOINT'];
+		delete process.env['AZURE_OPENAI_BASE_URL'];
+	});
+
+	teardown(() => {
+		if (savedApiKey !== undefined) { process.env['AZURE_OPENAI_API_KEY'] = savedApiKey; }
+		else { delete process.env['AZURE_OPENAI_API_KEY']; }
+		if (savedEndpoint !== undefined) { process.env['AZURE_OPENAI_ENDPOINT'] = savedEndpoint; }
+		else { delete process.env['AZURE_OPENAI_ENDPOINT']; }
+	});
+
+	const emptyFs = makeFileService(new Map());
+
+	test('returns null when no env key and no az token', async () => {
+		const result = await detectAzureCredentials(emptyFs, undefined, undefined);
+		assert.strictEqual(result, null);
+	});
+
+	test('env key overrides CLI token — returns env credential', async () => {
+		process.env['AZURE_OPENAI_API_KEY'] = 'env-key-1234abcd';
+		const result = await detectAzureCredentials(emptyFs, 'cli-bearer-token-xyz', 'https://my.openai.azure.com/');
+		assert.ok(result, 'expected a credential');
+		assert.strictEqual(result.source, 'env');
+		assert.strictEqual(result.settings.apiKey, 'env-key-1234abcd');
+		assert.ok(!result.maskedDisplay.includes('env-key-1234abcd'), 'full key must not appear in maskedDisplay');
+	});
+
+	test('CLI token returns cli-auth credential', async () => {
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		const result = await detectAzureCredentials(emptyFs, token, undefined);
+		assert.ok(result, 'expected a credential');
+		assert.strictEqual(result.providerName, 'microsoftAzure');
+		assert.strictEqual(result.source, 'cli-auth');
+		assert.strictEqual(result.settings.apiKey, token);
+		assert.strictEqual(result.settings['endpoint'], undefined, 'no endpoint should be set when azEndpoint is undefined');
+	});
+
+	test('CLI token + endpoint includes endpoint in settings', async () => {
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		const endpoint = 'https://my-resource.openai.azure.com/';
+		const result = await detectAzureCredentials(emptyFs, token, endpoint);
+		assert.ok(result);
+		assert.strictEqual(result.settings['endpoint'], endpoint);
+		assert.strictEqual(result.settings.apiKey, token);
+	});
+
+	test('no endpoint does not crash — credential still returned', async () => {
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		let result: Awaited<ReturnType<typeof detectAzureCredentials>> | undefined;
+		let threw = false;
+		try {
+			result = await detectAzureCredentials(emptyFs, token, undefined);
+		} catch {
+			threw = true;
+		}
+		assert.strictEqual(threw, false, 'must not throw when endpoint is undefined');
+		assert.ok(result, 'credential still returned without endpoint');
+	});
+
+	test('maskedDisplay does not contain full bearer token', async () => {
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		const result = await detectAzureCredentials(emptyFs, token, undefined);
+		assert.ok(result);
+		assert.ok(!result.maskedDisplay.includes(token), 'full bearer token must not appear in maskedDisplay');
+	});
+
+	test('subscription label from azureProfile.json appears in maskedDisplay', async () => {
+		const home = process.env['HOME'] || process.env['USERPROFILE'] || '';
+		if (!home) { return; }
+
+		const azureProfilePath = `${home}/.azure/azureProfile.json`.replace(/\\/g, '/');
+		const profile = JSON.stringify({
+			subscriptions: [{ name: 'My Subscription', id: 'sub-001', isDefault: true }],
+		});
+		const fs = makeFileService(new Map([[azureProfilePath, profile]]));
+
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		const result = await detectAzureCredentials(fs, token, undefined);
+		assert.ok(result);
+		assert.ok(result.maskedDisplay.includes('My Subscription'), 'subscription name should appear in maskedDisplay');
+		assert.ok(!result.maskedDisplay.includes(token), 'full token must not appear in maskedDisplay');
+	});
+
+	test('malformed azureProfile.json does not crash', async () => {
+		const home = process.env['HOME'] || process.env['USERPROFILE'] || '';
+		if (!home) { return; }
+
+		const azureProfilePath = `${home}/.azure/azureProfile.json`.replace(/\\/g, '/');
+		const fs = makeFileService(new Map([[azureProfilePath, '{ this is not valid json }']]));
+
+		const token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.dGVzdA.dGVzdA';
+		let threw = false;
+		try {
+			await detectAzureCredentials(fs, token, undefined);
+		} catch {
+			threw = true;
+		}
+		assert.strictEqual(threw, false, 'must not throw on malformed azureProfile.json');
 	});
 });
 


### PR DESCRIPTION
## Summary

- Shells out to `az account get-access-token --resource https://cognitiveservices.azure.com` to obtain a Cognitive Services bearer token for users logged in via `az login`
- Shells out to `az cognitiveservices account list` to auto-discover the Azure OpenAI endpoint (prefers `kind == "OpenAI"`)
- Updates `detectAzureCredentials()` so `AZURE_OPENAI_API_KEY` env var always wins; `az` CLI token is strategy 2; `azureProfile.json` is used only for subscription display label, never as a standalone credential
- Shows **"Azure OpenAI (az cli)"** label with the existing **experimental** badge in the Auto-Detect UI
- Graceful fallback on every failure path: `az` not installed, not logged in, no subscription, no Azure OpenAI resource, command timeout, parse error — all return `undefined` without crashing

## Files changed

| File | Change |
|------|--------|
| `autoConnectService.ts` | Added `_resolveAzToken()` and `_resolveAzEndpoint()`; both resolved in parallel with `_resolveGhToken()` at startup and on manual re-scan |
| `envVarDetector.ts` | Rewrote `detectAzureCredentials()`; updated `detectAllCredentials()` signature to accept `azCliToken` and `azCliEndpoint` |
| `Settings.tsx` | `displayTitle` shows "Azure OpenAI (az cli)" when `source === 'cli-auth'` for `microsoftAzure` |
| `envVarDetector.test.ts` | 8 new tests: no-token → null, env-key override, cli-auth credential, endpoint included, no-endpoint no-crash, masked display, subscription label from profile, malformed profile no-crash |

## Test plan

- [x] `npm run test-node` — all 4289 tests pass (8 new Azure tests all green)
- [x] TypeScript `--noEmit` check passes with 0 errors on changed files
- [x] App launches successfully via `scripts\code.bat`
- [x] With `az` not installed: Auto-Detect UI shows no Azure credential (graceful fallback confirmed)
- [ ] With `az login` active + Azure OpenAI resource present: Auto-Detect UI shows "Azure OpenAI (az cli)" with experimental badge and endpoint pre-filled

## Notes

This feature is **experimental** — the detection heuristic covers the standard `az login` interactive flow. Managed identity, service principal, and workload identity federation are not explicitly handled but will work if `az account get-access-token` succeeds for those auth flows.

Does not create, modify, or deploy any Azure resources. Detection-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)