### PR TITLE
fix: resolve all workflow/agent bugs from issue #125

### DIFF
--- a/src/vs/workbench/contrib/neuralInverse/browser/config/workflowVersioning.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/config/workflowVersioning.ts
@@ -60,7 +60,7 @@ export class WorkflowVersioning {
 			if (!await this.fileService.exists(historyDir)) {
 				await this.fileService.createFolder(historyDir);
 			}
-			const archiveUri = this._versionUri(current.id, nextVersion - 1 === 0 ? 1 : nextVersion - 1);
+			const archiveUri = this._versionUri(current.id, current.version ?? 0);
 			// Archive the OLD version (before the new one overwrites it)
 			const content = JSON.stringify({ ...current, _archivedAt: Date.now() }, null, 2);
 			await this.fileService.writeFile(archiveUri, VSBuffer.fromString(content));

--- a/src/vs/workbench/contrib/neuralInverse/browser/context/packer/contextPacker.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/context/packer/contextPacker.ts
@@ -315,7 +315,8 @@ class ContextPackerService extends Disposable implements IContextPackerService {
 		}
 
 		const result = parts.join('\n');
-		return { content: result, mode: 'imports-only' };
+		const hasSignatures = typeSymbols.length > 0 || funcSymbols.length > 0;
+		return { content: result, mode: hasSignatures ? 'signatures' : 'imports-only' };
 	}
 
 	private _extractChatContext(

--- a/src/vs/workbench/contrib/neuralInverse/browser/executor/toolCallParser.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/executor/toolCallParser.ts
@@ -39,7 +39,7 @@ export function parseToolCalls(text: string): IParsedToolCall[] {
 	const calls: IParsedToolCall[] = [];
 
 	// Match every ```json ... ``` block in the response
-	const blockRegex = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/g;
+	const blockRegex = /```(?:json)?\s*\n([\s\S]*?)\n?\s*```/g;
 	let match: RegExpExecArray | null;
 
 	while ((match = blockRegex.exec(text)) !== null) {
@@ -79,7 +79,7 @@ export function hasToolCalls(text: string): boolean {
  * Strip all JSON tool-call blocks from a response to get the prose around them.
  */
 export function stripToolCallBlocks(text: string): string {
-	return text.replace(/```(?:json)?\s*\n[\s\S]*?\n\s*```/g, '').trim();
+	return text.replace(/```(?:json)?\s*\n[\s\S]*?\n?\s*```/g, '').trim();
 }
 
 function _extractCall(obj: unknown): IParsedToolCall | null {

--- a/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/approvalGate.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/approvalGate.ts
@@ -74,10 +74,14 @@ export class ApprovalGateManager {
 		// Auto-approve timeout
 		if (request.autoApproveAt) {
 			const delayMs = Math.max(0, request.autoApproveAt - Date.now());
+			let handle: ReturnType<typeof setTimeout>;
 			const timeoutPromise = new Promise<IApprovalResponse>(resolve => {
-				setTimeout(() => resolve({ decision: 'approve' }), delayMs);
+				handle = setTimeout(() => resolve({ decision: 'approve' }), delayMs);
 			});
-			return Promise.race([userResponsePromise, timeoutPromise]).finally(cleanup);
+			return Promise.race([userResponsePromise, timeoutPromise]).finally(() => {
+				clearTimeout(handle);
+				cleanup();
+			});
 		}
 
 		return userResponsePromise.finally(cleanup);

--- a/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/conditionalEvaluator.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/conditionalEvaluator.ts
@@ -26,6 +26,31 @@
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
+ * Evaluate a mapping expression against a step's output string.
+ * Returns the raw evaluated value (string, number, boolean, object, etc.).
+ * Throws on syntax errors.
+ */
+export function evaluateExpression(output: string, expression: string): unknown {
+	let data: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(output);
+		data = (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))
+			? parsed as Record<string, unknown>
+			: { output: parsed };
+	} catch {
+		data = { output };
+	}
+
+	const tokens = _tokenize(expression);
+	const parser = new _Parser(tokens, data);
+	const result = parser.parseExpr();
+	if (parser.pos < tokens.length) {
+		throw new Error(`Unexpected token "${tokens[parser.pos].value}" at position ${parser.pos}`);
+	}
+	return result;
+}
+
+/**
  * Evaluate a condition expression against a step's output string.
  * Returns true/false. Throws on syntax errors.
  */

--- a/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/workflowComposer.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/workflowComposer.ts
@@ -29,6 +29,7 @@ import { IWorkflowStep, IAgentRun, IStepRun, IAgentDefinition, IToolExecutionCon
 import { ICancellationToken } from '../executor/agentExecutor.js';
 import { ToolResultCache } from '../executor/toolCache.js';
 import { BudgetTracker } from '../executor/budgetTracker.js';
+import { evaluateExpression } from './conditionalEvaluator.js';
 
 const MAX_NESTING_DEPTH = 5;
 
@@ -40,7 +41,7 @@ export class WorkflowComposer {
 	constructor(
 		// Circular type reference avoided via late binding — orchestrator passed at construction
 		private readonly orchestrator: {
-			run(workflow: import('../../common/workflowTypes.js').IWorkflowDefinition, run: IAgentRun, agents: Map<string, IAgentDefinition>, baseCtx: Omit<IToolExecutionContext, 'log'>, input: string, cancellation: ICancellationToken, onUpdate: (run: IAgentRun) => void): Promise<IAgentRun>;
+			run(workflow: import('../../common/workflowTypes.js').IWorkflowDefinition, run: IAgentRun, agents: Map<string, IAgentDefinition>, baseCtx: Omit<IToolExecutionContext, 'log'>, input: string, cancellation: ICancellationToken, onUpdate: (run: IAgentRun) => void, inheritedToolCache?: ToolResultCache, inheritedBudgetTracker?: BudgetTracker): Promise<IAgentRun>;
 			readonly approvalGate: import('./approvalGate.js').ApprovalGateManager;
 			workflowResolver?: (id: string) => import('../../common/workflowTypes.js').IWorkflowDefinition | undefined;
 		},
@@ -91,12 +92,22 @@ export class WorkflowComposer {
 		// ── Build input ───────────────────────────────────────────────────────
 		let subInput = input;
 		if (subConfig.inputMapping) {
-			// Use the prior step output as the base for input mapping
+			// Evaluate the mapping expression against upstream step outputs
 			const upstreamOutput = (step.dependsOn ?? [])
 				.map(id => stepOutputs.get(id))
 				.filter(Boolean)
 				.join('\n\n');
-			if (upstreamOutput) subInput = upstreamOutput;
+			if (upstreamOutput) {
+				try {
+					const mapped = evaluateExpression(upstreamOutput, subConfig.inputMapping);
+					subInput = typeof mapped === 'string' ? mapped : JSON.stringify(mapped);
+				} catch (e: any) {
+					stepRun.status = 'failed';
+					stepRun.error = `inputMapping expression error: ${e.message}`;
+					stepRun.endedAt = Date.now();
+					return;
+				}
+			}
 		}
 
 		// ── Run sub-workflow ──────────────────────────────────────────────────
@@ -125,6 +136,7 @@ export class WorkflowComposer {
 			await this.orchestrator.run(
 				subWorkflow, subRun, agents, baseCtx, subInput, cancellation,
 				(r) => onUpdate(parentRun), // fire parent run events to keep UI updated
+				toolCache, budgetTracker,
 			);
 
 			if (subRun.status === 'done') {

--- a/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/workflowOrchestrator.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/orchestrator/workflowOrchestrator.ts
@@ -82,6 +82,8 @@ export class WorkflowOrchestrator {
 		input: string,
 		cancellation: ICancellationToken,
 		onUpdate: RunUpdateCallback,
+		inheritedToolCache?: ToolResultCache,
+		inheritedBudgetTracker?: BudgetTracker,
 	): Promise<IAgentRun> {
 
 		run.status = 'planning';
@@ -108,11 +110,11 @@ export class WorkflowOrchestrator {
 		// Step IDs deactivated by conditional branches at runtime
 		const branchInactiveIds = new Set<string>();
 
-		// Per-run tool result cache (shared across all steps)
-		const toolCache = new ToolResultCache();
+		// Per-run tool result cache (shared across all steps; inherited by sub-workflows)
+		const toolCache = inheritedToolCache ?? new ToolResultCache();
 
-		// Per-run budget tracker (undefined if no budget configured)
-		const budgetTracker = workflow.budget ? new BudgetTracker(workflow.budget) : undefined;
+		// Per-run budget tracker (undefined if no budget configured; inherited by sub-workflows)
+		const budgetTracker = inheritedBudgetTracker ?? (workflow.budget ? new BudgetTracker(workflow.budget) : undefined);
 
 		// Sub-workflow composer (for cross-workflow composition)
 		const composer = new WorkflowComposer(this);
@@ -279,7 +281,7 @@ export class WorkflowOrchestrator {
 			},
 		};
 
-		const stepInput = this._buildStepInput(step, input, priorOutputs, priorOutputs.length === 0 ? 0 : 1);
+		const stepInput = this._buildStepInput(step, input, priorOutputs, priorOutputs.length > 0);
 
 		// ── Retry loop ────────────────────────────────────────────────────────
 		const retryConfig = step.retry;
@@ -477,9 +479,9 @@ export class WorkflowOrchestrator {
 		step: IWorkflowStep,
 		originalInput: string,
 		priorOutputs: IPriorStepOutput[],
-		stepIndex: number,
+		hasPriorOutputs: boolean,
 	): string {
-		if (stepIndex === 0 || priorOutputs.length === 0) {
+		if (!hasPriorOutputs || priorOutputs.length === 0) {
 			return originalInput;
 		}
 		// For downstream steps, inject the original goal so context is maintained

--- a/src/vs/workbench/contrib/neuralInverse/browser/tools/fsTools.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/tools/fsTools.ts
@@ -255,7 +255,8 @@ export class SearchCodeTool implements IAgentTool {
 			try {
 				const content = (await ctx.fileService.readFile(uri)).value.toString();
 				const lines = content.split('\n');
-				const relativePath = uri.path;
+				const wsPath = ctx.workspaceUri.path.endsWith('/') ? ctx.workspaceUri.path : ctx.workspaceUri.path + '/';
+				const relativePath = uri.path.startsWith(wsPath) ? uri.path.slice(wsPath.length) : uri.path;
 				for (let i = 0; i < lines.length && matches.length < maxResults; i++) {
 					if (regex.test(lines[i])) {
 						matches.push(`${relativePath}:${i + 1}: ${lines[i].trim()}`);

--- a/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
@@ -225,6 +225,9 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 			},
 		));
 
+		// Seed triggers with whatever workflows are already loaded
+		this._triggerManager.refresh(this._configLoader.getWorkflows());
+
 		// Wire sub-workflow resolver so WorkflowComposer can look up workflows by ID
 		this._orchestrator.workflowResolver = (id: string) => this._configLoader.getWorkflow(id);
 
@@ -280,8 +283,9 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 			a.name.toLowerCase().replace(/\s+/g, '-'),
 			a,
 		]));
-		// Also index by raw name
+		// Also index by id and raw name
 		for (const a of this.agentStore.getAgents()) {
+			agentMap.set(a.id, a);
 			agentMap.set(a.name, a);
 		}
 
@@ -343,42 +347,46 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 				allowedTools: [...ALL_FS_TOOLS, ...ALL_TERMINAL_TOOLS, ...ALL_GIT_TOOLS, ...ALL_HTTP_TOOLS].map(t => t.name),
 			}],
 		};
-		return this.runWorkflow(syntheticWorkflow.id, input, 'manual').catch(async () => {
-			// Workflow not in registry — use the synthetic one directly
-			const run = buildAgentRun(syntheticWorkflow, { kind: 'manual' });
-			const cancellation: ICancellationToken = { cancelled: false };
-			const agentMap = new Map(this.agentStore.getAgents().map(a => [a.name, a]));
-			const folder = this.workspaceContextService.getWorkspace().folders[0];
+		const run = buildAgentRun(syntheticWorkflow, { kind: 'manual' });
+		const cancellation: ICancellationToken = { cancelled: false };
+		const agentMap = new Map(this.agentStore.getAgents().map(a => [
+			a.name.toLowerCase().replace(/\s+/g, '-'),
+			a,
+		]));
+		for (const a of this.agentStore.getAgents()) {
+			agentMap.set(a.id, a);
+			agentMap.set(a.name, a);
+		}
+		const folder = this.workspaceContextService.getWorkspace().folders[0];
 
-			this._activeRuns.set(run.id, run);
-			this._activeCancellations.set(run.id, cancellation);
-			this._onDidChangeRun.fire(run);
+		this._activeRuns.set(run.id, run);
+		this._activeCancellations.set(run.id, cancellation);
+		this._onDidChangeRun.fire(run);
 
-			if (!folder) {
-				run.status = 'failed';
-				run.error = 'No workspace folder open';
-				run.endedAt = Date.now();
-				this._finalizeRun(run);
-				return run;
-			}
-
-			const agentModelSel = this.settingsService.state.modelSelectionOfFeature['Chat'];
-			const baseCtx = { workspaceUri: folder.uri, fileService: this.fileService, modelInfo: agentModelSel ? { provider: agentModelSel.providerName, model: agentModelSel.modelName } : undefined };
-
-			try {
-				await this._orchestrator.run(
-					syntheticWorkflow, run, agentMap, baseCtx, input, cancellation,
-					(r) => this._onDidChangeRun.fire(r),
-				);
-			} catch (e: any) {
-				run.status = 'failed';
-				run.error = e.message;
-				run.endedAt = Date.now();
-			}
-
+		if (!folder) {
+			run.status = 'failed';
+			run.error = 'No workspace folder open';
+			run.endedAt = Date.now();
 			this._finalizeRun(run);
 			return run;
-		});
+		}
+
+		const agentModelSel = this.settingsService.state.modelSelectionOfFeature['Chat'];
+		const baseCtx = { workspaceUri: folder.uri, fileService: this.fileService, modelInfo: agentModelSel ? { provider: agentModelSel.providerName, model: agentModelSel.modelName } : undefined };
+
+		try {
+			await this._orchestrator.run(
+				syntheticWorkflow, run, agentMap, baseCtx, input, cancellation,
+				(r) => this._onDidChangeRun.fire(r),
+			);
+		} catch (e: any) {
+			run.status = 'failed';
+			run.error = e.message;
+			run.endedAt = Date.now();
+		}
+
+		this._finalizeRun(run);
+		return run;
 	}
 
 	cancelRun(runId: string): void {

--- a/src/vs/workbench/contrib/neuralInverse/browser/workflowConfigLoader.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/workflowConfigLoader.ts
@@ -80,12 +80,13 @@ export class WorkflowConfigLoader extends Disposable {
 		return t;
 	}
 
-	private async _waitForFile(file: URI, timeoutMs = 5000): Promise<void> {
+	private async _waitForFile(file: URI, timeoutMs = 5000): Promise<boolean> {
 		const start = Date.now();
 		while (Date.now() - start < timeoutMs) {
-			try { if (await this.fileService.exists(file)) return; } catch { }
+			try { if (await this.fileService.exists(file)) return true; } catch { }
 			await new Promise<void>(r => setTimeout(r, 200));
 		}
+		return false;
 	}
 
 	private async _withWriteAccess(fn: () => Promise<void>): Promise<void> {
@@ -115,7 +116,9 @@ export class WorkflowConfigLoader extends Disposable {
 				? `attrib +r "${inversePath}\\*" /s && echo DONE > "${statusFile.fsPath}"`
 				: `chmod -R a-w "${inversePath}" && echo "DONE" > "${statusFile.fsPath}"`;
 			terminal.sendText(lockCmd, true);
-			await this._waitForFile(statusFile);
+			if (!await this._waitForFile(statusFile)) {
+				throw new Error('[WorkflowConfigLoader] Timed out re-acquiring .inverse/ write lock');
+			}
 			try { await this.fileService.del(statusFile); } catch { }
 		}
 	}
@@ -247,8 +250,8 @@ export class WorkflowConfigLoader extends Disposable {
 		const fileUri = URI.joinPath(inverseDirUri, WORKFLOWS_DIR, `${def.id}.json`);
 
 		// Archive prior version inside the write-access window, then save with bumped version
+		let defToSave = def;
 		await this._withWriteAccess(async () => {
-			let defToSave = def;
 			if (this._versioning) {
 				defToSave = await this._versioning.archive(def);
 			}
@@ -256,7 +259,7 @@ export class WorkflowConfigLoader extends Disposable {
 			await this.fileService.writeFile(fileUri, VSBuffer.fromString(json));
 		});
 
-		console.log(`[WorkflowConfigLoader] Saved workflow: ${def.id} (v${(def.version ?? 0) + 1})`);
+		console.log(`[WorkflowConfigLoader] Saved workflow: ${defToSave.id} (v${defToSave.version ?? 1})`);
 	}
 
 	/** List all archived versions for a workflow */


### PR DESCRIPTION
## Summary

Fixes 13 confirmed bugs from GitHub issue #125 across the NeuralInverse workflow engine and agent service. Two items (#6, #7) were audited and found to already be correct. Item #16 is intentionally skipped (GRC tools registered with null engine — CE stub by design).

### Fixed
- **#1 Agent lookup** — `agentMap` now indexed by `id`, slugified name, and raw name; previously only raw name, causing "agent not found" for programmatic calls
- **#2 runAgent synthetic workflow** — removed broken `.catch()` fallback path that made the happy path unreachable
- **#3 Trigger refresh** — `TriggerManager.refresh()` now called on init to seed workflows already in registry at startup
- **#4 WorkflowVersioning archive** — archives to `current.version` (the version being overwritten), not `nextVersion - 1` (which was off-by-one for v0 documents)
- **#5 Shared budgetTracker/toolCache** — sub-workflows now inherit parent's `ToolResultCache` and `BudgetTracker` via new optional params on `orchestrator.run()`
- **#8 ToolCallParser regex** — closing ` ``` ` no longer requires a preceding newline (`\n` → `\n?`), fixing parse failures on tight code fences
- **#9 SearchCodeTool paths** — strips workspace root prefix from file URIs to produce relative paths instead of absolute
- **#10 Write lock timeout** — `_waitForFile` now returns `boolean`; call site throws a descriptive error on timeout instead of silently continuing
- **#11 inputMapping expression** — mapping expressions are now evaluated via `conditionalEvaluator.evaluateExpression()` rather than a raw upstream-output copy
- **#12 Approval timer cleanup** — `clearTimeout()` is now called in `.finally()` so the auto-approve timer is cancelled when the user responds first
- **#13 ContextPacker extraction mode** — returns `mode: 'signatures'` when type/function symbols are present; was always returning `'imports-only'`
- **#14 saveWorkflow version log** — log now reflects the version actually written to disk (post-`archive()`), not a pre-increment estimate
- **#15 stepIndex → hasPriorOutputs** — renamed parameter from `stepIndex: number` to `hasPriorOutputs: boolean` for semantic correctness

## Test plan

- [ ] Run a multi-step workflow with a named agent — verify lookup succeeds by `id`
- [ ] Call `runAgent()` ad-hoc — verify it executes without falling into the `.catch()` path
- [ ] Start the service with pre-existing workflows — verify triggers fire at startup
- [ ] Save a workflow twice — verify archive file uses the correct version number
- [ ] Run a nested sub-workflow — verify it shares parent's tool cache and budget
- [ ] Send an LLM response with a tight code fence (no trailing newline before ` ``` `) — verify tool calls are parsed
- [ ] Run `SearchCodeTool` — verify output paths are workspace-relative
- [ ] Trigger a workflow that holds a write lock — verify timeout produces an error message
- [ ] Use `inputMapping` in a sub-workflow config — verify expression is evaluated against upstream output
- [ ] Approve a prompt before auto-approve timer fires — verify timer is cleared
- [ ] Pack context for a file with type/function symbols — verify `mode: 'signatures'` is returned
- [ ] Save a new workflow (v0) — verify log prints `v1`, not `v1` from an off-by-one estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)