### PR TITLE
fix(workflow): resolve agents by id in runWorkflow/runAgent lookup maps

### DIFF
--- a/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
@@ -275,13 +275,11 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 		if (!workflow.enabled) throw new Error(`Workflow "${workflowId}" is disabled`);
 
 		// Build agent map from AgentRegistryService
-		const agentMap = new Map(this.agentStore.getAgents().map(a => [
-			// AgentRegistryService uses name as key; we also try the file basename
-			a.name.toLowerCase().replace(/\s+/g, '-'),
-			a,
-		]));
-		// Also index by raw name
+		// Workflow steps reference agents by `id`; keep name aliases for
+		// definitions written before ids were stable.
+		const agentMap = new Map(this.agentStore.getAgents().map(a => [a.id, a]));
 		for (const a of this.agentStore.getAgents()) {
+			agentMap.set(a.name.toLowerCase().replace(/\s+/g, '-'), a);
 			agentMap.set(a.name, a);
 		}
 
@@ -347,7 +345,11 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 			// Workflow not in registry — use the synthetic one directly
 			const run = buildAgentRun(syntheticWorkflow, { kind: 'manual' });
 			const cancellation: ICancellationToken = { cancelled: false };
-			const agentMap = new Map(this.agentStore.getAgents().map(a => [a.name, a]));
+			const agentMap = new Map(this.agentStore.getAgents().map(a => [a.id, a]));
+			for (const a of this.agentStore.getAgents()) {
+				agentMap.set(a.name.toLowerCase().replace(/\s+/g, '-'), a);
+				agentMap.set(a.name, a);
+			}
 			const folder = this.workspaceContextService.getWorkspace().folders[0];
 
 			this._activeRuns.set(run.id, run);


### PR DESCRIPTION
Fixes #133

## Problem

Workflow steps reference agents by `id` (`steps[].agentId`), but both agent lookup maps in `WorkflowAgentService` were keyed by display name only:

- `runWorkflow` keyed by `slug(name)` + raw `name`
- the `runAgent` fallback keyed by raw `name` only

Every builtin agent whose name differs from its id (e.g. "API Designer" vs "api-designer") therefore failed with:

```
Agent definition "api-designer" not found in .inverse/agents/
```

including **all 11 builtin agents**, out of the box, for every user running an agent from the Agents tab.

## Change

Key both maps by `id` first (the canonical field per `IAgentDefinition` — `.inverse/agents/<id>.json`), keeping `slug(name)` and raw `name` as legacy aliases for backward compatibility with hand-written definitions that reference agents by name:

```ts
const agentMap = new Map(this.agentStore.getAgents().map(a => [a.id, a]));
for (const a of this.agentStore.getAgents()) {
    agentMap.set(a.name.toLowerCase().replace(/\s+/g, '-'), a);
    agentMap.set(a.name, a);
}
```

Two small, contained edits in `workflowAgentService.ts`; no behavior change for definitions where `name === id` or where steps already referenced `slug(name)`.

## Notes / follow-ups (not in this PR)

- ad-hoc workflow from `runAgent` is never registered in the configLoader, so the primary path always throws and every single-agent run goes through the fallback (issue #133, Bug 3)
- `AgentStoreService` hydrates asynchronously; an immediate run after opening the panel can hit an empty store (issue #133, Bug 4) — a `whenReady` gate would fix it

Happy to take those on in follow-up PRs. Also interested in contributing to the agent orchestration side of the project longer-term (multi-agent channels / team workflows).