### PR TITLE
fix(updater): skip update whose version matches the installed version

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -219,7 +219,12 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 			.then(update => {
 				const updateType = getUpdateType();
 
-				if (!update || !update.url || !update.version || !update.productVersion) {
+				if (!update || !update.url || !update.version || !update.productVersion
+					// Update feeds that ignore the commit hash (release-server
+					// returning the latest build unconditionally) would offer the
+					// already-installed version forever; compare versions client-side.
+					|| update.version === this.productService.version
+				) {
 					// If we were checking for an overwrite update and found nothing newer,
 					// restore the Ready state with the pending update
 					if (this.state.type === StateType.Overwriting) {


### PR DESCRIPTION
Fixes #135 (item 1).

## Problem

The update API returns the latest release for **any** commit hash (verified: the same 1.1.3 payload comes back for the real commit, an all-zero commit, and a random string — never a 204 up-to-date response). Combined with builds stamping `product.json` with the VS Code base version (`1.99.3`) instead of the release version, the win32 updater offers the **already-installed** build on every start:

- users install 1.1.3, restart, and see the same "Neural Inverse 1.1.3 is available" banner again (endless loop),
- Help → About keeps showing the stale base version, so it genuinely looks like the update never applied.

## Change

In `updateService.win32.ts` `doCheckForUpdates`, treat an update whose `version` equals the installed `productService.version` as up-to-date — the same code path as a missing/invalid update payload:

```ts
if (!update || !update.url || !update.version || !update.productVersion
    // Update feeds that ignore the commit hash would offer the
    // already-installed version forever; compare versions client-side.
    || update.version === this.productService.version
) { ...Idle... }
```

One condition, one file, no behavior change for feeds that behave like the standard VS Code update server (they return no payload when current).

## Note

This guard alone doesn't fix the version reporting — for it to ever match, releases also need to stamp the real version into `product.json` (issue #135 items 2–3: server-side 204 + build metadata). I kept this PR minimal and client-side; happy to take the rest in follow-ups.