### PR TITLE
fix(workflow): resolve agents by id in runWorkflow/runAgent lookup maps

### DIFF
--- a/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
+++ b/src/vs/workbench/contrib/neuralInverse/browser/workflowAgentService.ts
@@ -275,13 +275,11 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 		if (!workflow.enabled) throw new Error(`Workflow "${workflowId}" is disabled`);
 
 		// Build agent map from AgentRegistryService
-		const agentMap = new Map(this.agentStore.getAgents().map(a => [
-			// AgentRegistryService uses name as key; we also try the file basename
-			a.name.toLowerCase().replace(/\s+/g, '-'),
-			a,
-		]));
-		// Also index by raw name
+		// Workflow steps reference agents by `id`; keep name aliases for
+		// definitions written before ids were stable.
+		const agentMap = new Map(this.agentStore.getAgents().map(a => [a.id, a]));
 		for (const a of this.agentStore.getAgents()) {
+			agentMap.set(a.name.toLowerCase().replace(/\s+/g, '-'), a);
 			agentMap.set(a.name, a);
 		}
 
@@ -347,7 +345,11 @@ export class WorkflowAgentService extends Disposable implements IWorkflowAgentSe
 			// Workflow not in registry — use the synthetic one directly
 			const run = buildAgentRun(syntheticWorkflow, { kind: 'manual' });
 			const cancellation: ICancellationToken = { cancelled: false };
-			const agentMap = new Map(this.agentStore.getAgents().map(a => [a.name, a]));
+			const agentMap = new Map(this.agentStore.getAgents().map(a => [a.id, a]));
+			for (const a of this.agentStore.getAgents()) {
+				agentMap.set(a.name.toLowerCase().replace(/\s+/g, '-'), a);
+				agentMap.set(a.name, a);
+			}
 			const folder = this.workspaceContextService.getWorkspace().folders[0];
 
 			this._activeRuns.set(run.id, run);


### PR DESCRIPTION
## Problem

Workflow steps reference agents by `steps[].agentId`, but both agent lookup maps in `WorkflowAgentService` were keyed by **display name** only:

- `runWorkflow` used `slug(name)` + `name`
- `runAgent` fallback used raw `name`

Every builtin agent whose name differs from its id (e.g. `"API Designer"` vs `"api-designer"`) failed at run time with:

```
Agent definition "X" not found in .inverse/agents/
```

## Fix

Key both maps by `id` first (the canonical identity — `IAgentDefinition.id`), keeping `slug(name)` and `name` as legacy aliases for backward compatibility with existing workflow files that reference agents by display name.

## Testing

- ✅ Workflow runs with `agentId` references resolve correctly for builtin agents whose name ≠ id
- ✅ Existing workflows referencing agents by display name keep working (alias path)
- ✅ Live-tested on the installed Windows build

## Notes

Supersedes #134, which became unopenable after administrative repo changes on our side (the head-repo link was dropped). Refs #133.