### PR TITLE
fix(updater): skip update whose version matches the installed version

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -219,7 +219,12 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 			.then(update => {
 				const updateType = getUpdateType();
 
-				if (!update || !update.url || !update.version || !update.productVersion) {
+				if (!update || !update.url || !update.version || !update.productVersion
+					// Update feeds that ignore the commit hash (release-server
+					// returning the latest build unconditionally) would offer the
+					// already-installed version forever; compare versions client-side.
+					|| update.version === this.productService.version
+				) {
 					// If we were checking for an overwrite update and found nothing newer,
 					// restore the Ready state with the pending update
 					if (this.state.type === StateType.Overwriting) {


### PR DESCRIPTION
## Problem

The update API returns the latest release for **any** commit hash (it never responds `204 up-to-date`), and builds stamp `product.json` with the VS Code base version. As a result, `checkForUpdates` offers the already-installed build on every start — an endless update banner users cannot escape.

## Fix

Compare the feed's returned version against the installed product version and treat a match as up-to-date (same code path as a missing update). A client-side guard, independent of any server-side fix.

## Testing

- ✅ With installed version == feed version: no banner, state resolves to up-to-date
- ✅ With a genuinely newer feed version: banner appears as before
- ✅ Live-tested on the installed Windows build

Fixes #135 (item 1).

## Notes

Supersedes #136, which became unopenable after administrative repo changes on our side (the head-repo link was dropped).